### PR TITLE
Remove adversarial training support

### DIFF
--- a/configs/accelerate/default_config.yaml
+++ b/configs/accelerate/default_config.yaml
@@ -1,0 +1,17 @@
+compute_environment: LOCAL_MACHINE
+debug: false
+distributed_type: MULTI_GPU
+downcast_bf16: 'no'
+enable_cpu_affinity: true
+gpu_ids: 0,1,3
+machine_rank: 0
+main_training_function: main
+mixed_precision: 'no'
+num_machines: 1
+num_processes: 3
+rdzv_backend: static
+same_network: true
+tpu_env: []
+tpu_use_cluster: false
+tpu_use_sudo: false
+use_cpu: false

--- a/configs/vae_2x_1024ch/4x_L40S_config.yaml
+++ b/configs/vae_2x_1024ch/4x_L40S_config.yaml
@@ -7,8 +7,8 @@ project: "simple_latent_solo_model"
 save_root_dir: "simple_latent_solo_model"
 
 dataset:
-  model_resolution: 128
-  high_resolution: 256
+  model_resolution: 64
+  high_resolution: 128
   resize_long_side: 1280
   limit: 0
   num_workers: 24
@@ -30,7 +30,7 @@ model:
   torch_compile_fullgraph: false
 
 optimizer:
-  batch_size: 24
+  batch_size: 90
   base_learning_rate: 1.0
   min_learning_rate: 9e-7
   num_epochs: 750
@@ -53,13 +53,15 @@ loss:
     lpips: true
     ffl: true
     kl: true
+    adv: true
   ratios:
     mae: 0.35
     mse: 0.05
     edge: 0.10
     lpips: 0.25
     ffl: 0.15
-    kl: 0.10
+    kl: 0.0
+    adv: 0.10
   median_coeff_steps: 256
   lpips_backbone: "vgg"
   lpips_eval_resolution: 256
@@ -71,10 +73,28 @@ loss:
     normalize: true
     eps: 1.0e-08
 
+adversarial:
+  enabled: false
+  loss_type: "ragan"
+  update_frequency: 1
+  warmup_steps: 1000
+  discriminator:
+    base_channels: 64
+    max_channels: 512
+    num_layers: 4
+    norm: "instance"
+    spectral_norm: true
+  optimizer:
+    lr: 1.5e-4
+    beta1: 0.9
+    beta2: 0.99
+    weight_decay: 0.0
+    clip_grad_norm: 1.0
+
 logging:
   use_wandb: true
   sample_interval_share: 1000
-  global_sample_interval: 100
+  global_sample_interval: 25
   global_save_interval: 1000
   save_model: true
   save_barrier: 1.003
@@ -91,7 +111,7 @@ augmentation:
   horizontal_flip_prob: 0.5
 
 ema:
-  enabled: true
+  enabled: false
   decay: 0.999
   update_after_step: 100
   update_interval: 1

--- a/configs/vae_2x_1024ch/train_config.yaml
+++ b/configs/vae_2x_1024ch/train_config.yaml
@@ -1,21 +1,22 @@
 # Baseline single-node configuration. Override values via additional YAML files
 # or the CLI --override flag.
 
-ds_path: "./workspace/d23/d23/ae3/"
+ds_path: "./workspace/d23/test_dataset" # test dataset path
+
 project: "simple_latent_solo_model"
 save_root_dir: "simple_latent_solo_model"
 
 dataset:
-  model_resolution: 256
-  high_resolution: 512
+  model_resolution: 64
+  high_resolution: 128
   resize_long_side: 1280
   limit: 0
-  num_workers: 10
+  num_workers: 24
   horizontal_flip_prob: 0.5
   persistent_workers: true
 
 model:
-  load_from: "simple_latent_solo_model/2025_10_05_08_new_loss_exp/final/"
+  load_from: ""
   hf_repo: "AuraDiffusion/16ch-vae"
   dtype: "bfloat16"
   mixed_precision: "bf16"
@@ -29,10 +30,10 @@ model:
   torch_compile_fullgraph: false
 
 optimizer:
-  batch_size: 14
+  batch_size: 102
   base_learning_rate: 1.0
   min_learning_rate: 9e-7
-  num_epochs: 25
+  num_epochs: 750
   optimizer_type: "dadapt_adam"
   beta2: 0.97
   eps: 1e-6
@@ -57,9 +58,9 @@ loss:
     mae: 0.35
     mse: 0.05
     edge: 0.10
-    lpips: 0.35
+    lpips: 0.25
     ffl: 0.15
-    kl: 0.00
+    kl: 0.10
     adv: 0.10
   median_coeff_steps: 256
   lpips_backbone: "vgg"
@@ -93,8 +94,8 @@ adversarial:
 logging:
   use_wandb: true
   sample_interval_share: 1000
-  global_sample_interval: 50
-  global_save_interval: 500
+  global_sample_interval: 100
+  global_save_interval: 1000
   save_model: true
   save_barrier: 1.003
   log_grad_norm: true

--- a/configs/vae_2x_1024ch/train_config.yaml
+++ b/configs/vae_2x_1024ch/train_config.yaml
@@ -12,6 +12,7 @@ dataset:
   limit: 0
   num_workers: 10
   horizontal_flip_prob: 0.5
+  persistent_workers: true
 
 model:
   load_from: "simple_latent_solo_model/2025_10_05_08_new_loss_exp/final/"
@@ -51,6 +52,7 @@ loss:
     lpips: true
     ffl: true
     kl: true
+    adv: true
   ratios:
     mae: 0.35
     mse: 0.05
@@ -58,6 +60,7 @@ loss:
     lpips: 0.35
     ffl: 0.15
     kl: 0.00
+    adv: 0.10
   median_coeff_steps: 256
   lpips_backbone: "vgg"
   lpips_eval_resolution: 256
@@ -68,6 +71,24 @@ loss:
     ave_spectrum: false
     normalize: true
     eps: 1.0e-08
+
+adversarial:
+  enabled: true
+  loss_type: "ragan"
+  update_frequency: 1
+  warmup_steps: 1000
+  discriminator:
+    base_channels: 64
+    max_channels: 512
+    num_layers: 4
+    norm: "instance"
+    spectral_norm: true
+  optimizer:
+    lr: 1.5e-4
+    beta1: 0.9
+    beta2: 0.99
+    weight_decay: 0.0
+    clip_grad_norm: 1.0
 
 logging:
   use_wandb: true

--- a/configs/vae_2x_1024ch/train_config.yaml
+++ b/configs/vae_2x_1024ch/train_config.yaml
@@ -53,7 +53,6 @@ loss:
     lpips: true
     ffl: true
     kl: true
-    adv: true
   ratios:
     mae: 0.35
     mse: 0.05
@@ -61,7 +60,6 @@ loss:
     lpips: 0.25
     ffl: 0.15
     kl: 0.10
-    adv: 0.10
   median_coeff_steps: 256
   lpips_backbone: "vgg"
   lpips_eval_resolution: 256
@@ -72,24 +70,6 @@ loss:
     ave_spectrum: false
     normalize: true
     eps: 1.0e-08
-
-adversarial:
-  enabled: true
-  loss_type: "ragan"
-  update_frequency: 1
-  warmup_steps: 1000
-  discriminator:
-    base_channels: 64
-    max_channels: 512
-    num_layers: 4
-    norm: "instance"
-    spectral_norm: true
-  optimizer:
-    lr: 1.5e-4
-    beta1: 0.9
-    beta2: 0.99
-    weight_decay: 0.0
-    clip_grad_norm: 1.0
 
 logging:
   use_wandb: true

--- a/configs/vae_2x_1024ch/train_config.yaml
+++ b/configs/vae_2x_1024ch/train_config.yaml
@@ -102,6 +102,9 @@ logging:
 latent_upscaler:
   enabled: true
   width_multiplier: 2
+  rrdb_blocks: 8
+  growth_channels: 32
+  residual_scaling: 0.2
 
 augmentation:
   horizontal_flip_prob: 0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ dadaptation>=3.1
 # Experiment tracking and visualization
 wandb==0.22.1
 matplotlib==3.10.6
+tqdm>=4.66.0

--- a/scripts/create_test_dataset.ipynb
+++ b/scripts/create_test_dataset.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1f7c3c35",
+   "metadata": {},
+   "source": [
+    "# Build a 10K-image test dataset\n",
+    "This notebook samples a fixed number of images from the full dataset at `./workspace/d23/d23/` and copies them into a dedicated test split folder."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "901f7a36",
+   "metadata": {},
+   "source": [
+    "## Workflow\n",
+    "1. Configure source and destination paths plus sampling options.\n",
+    "2. Index all image files recursively under the source root.\n",
+    "3. Randomly sample 10,000 unique paths (reproducible with a fixed seed).\n",
+    "4. Copy the sampled files into a new `test_dataset` folder while preserving their subdirectory structure.\n",
+    "5. Validate the copy by recounting files in the test split."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c8e6d753",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset root: /home/kazanplova/projects/latent_vae_upscale_train/workspace/d23/d23\n",
+      "Test split destination: /home/kazanplova/projects/latent_vae_upscale_train/workspace/d23/test_dataset\n",
+      "Target sample size: 10000\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "import random\n",
+    "import shutil\n",
+    "import os\n",
+    "\n",
+    "# --- Configuration ---\n",
+    "dataset_root = Path(\"./workspace/d23/d23\")  # full dataset\n",
+    "test_root = Path(\"./workspace/d23/test_dataset\")  # output folder for the sampled test split\n",
+    "sample_count = 10_000\n",
+    "random_seed = 1337\n",
+    "overwrite_existing = False  # set to True to delete and recreate the test folder if it already exists\n",
+    "\n",
+    "image_extensions = {\".png\", \".jpg\", \".jpeg\", \".bmp\", \".webp\", \".gif\"}\n",
+    "\n",
+    "assert dataset_root.exists() and dataset_root.is_dir(), f\"Dataset root {dataset_root} is missing\"\n",
+    "\n",
+    "if test_root.exists():\n",
+    "    if overwrite_existing:\n",
+    "        shutil.rmtree(test_root)\n",
+    "    else:\n",
+    "        raise FileExistsError(f\"Destination {test_root} already exists. Set overwrite_existing=True to rebuild it.\")\n",
+    "\n",
+    "test_root.mkdir(parents=True, exist_ok=True)\n",
+    "print(f\"Dataset root: {dataset_root.resolve()}\")\n",
+    "print(f\"Test split destination: {test_root.resolve()}\")\n",
+    "print(f\"Target sample size: {sample_count}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f8e746f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total images discovered: 154598\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Index all image files under the dataset root\n",
+    "all_images = []\n",
+    "for path, _, files in os.walk(dataset_root):\n",
+    "    for name in files:\n",
+    "        ext = Path(name).suffix.lower()\n",
+    "        if ext in image_extensions:\n",
+    "            all_images.append(Path(path) / name)\n",
+    "\n",
+    "total_images = len(all_images)\n",
+    "print(f\"Total images discovered: {total_images}\")\n",
+    "if total_images < sample_count:\n",
+    "    raise ValueError(f\"Requested {sample_count} samples but only found {total_images} eligible images.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d0dafa18",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/kazanplova/anaconda3/envs/wan2_1/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sampled 10000 images.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 10000/10000 [00:25<00:00, 390.21it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finished copying sampled files.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from tqdm.auto import tqdm\n",
+    "# Sample unique image paths using a reproducible RNG\n",
+    "rng = random.Random(random_seed)\n",
+    "sampled_paths = rng.sample(all_images, sample_count)\n",
+    "print(f\"Sampled {len(sampled_paths)} images.\")\n",
+    "\n",
+    "# Copy each sampled image while recreating its relative directory tree\n",
+    "for src_path in tqdm(sampled_paths):\n",
+    "    relative_path = src_path.relative_to(dataset_root)\n",
+    "    dest_path = test_root / relative_path\n",
+    "    dest_path.parent.mkdir(parents=True, exist_ok=True)\n",
+    "    shutil.copy2(src_path, dest_path)\n",
+    "\n",
+    "print(\"Finished copying sampled files.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fc6f2ad1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Images inside test split: 10000\n",
+      "Sample preview:\n",
+      " - ApromaWp/ApromaWp_13040905.png\n",
+      " - ApromaWp/ApromaWp_854586d5.png\n",
+      " - ApromaWp/ApromaWp_978606d8.png\n",
+      " - ApromaWp/ApromaWp_e36bbc7f.png\n",
+      " - ApromaWp/ApromaWp_f167e7ad.png\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Quick verification of the resulting test split\n",
+    "copied_images = [p for p in test_root.rglob('*') if p.suffix.lower() in image_extensions]\n",
+    "print(f\"Images inside test split: {len(copied_images)}\")\n",
+    "print(\"Sample preview:\")\n",
+    "for preview_path in copied_images[:5]:\n",
+    "    print(f\" - {preview_path.relative_to(test_root)}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "wan2_1",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/pack_and_upload_dataset.py
+++ b/scripts/pack_and_upload_dataset.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Pack a large image dataset into compressed archives and upload to Hugging Face.
+
+The script walks a dataset directory, batches files into `.tar.gz` archives with
+maximum compression (lossless for pre-compressed image formats), and uploads the
+resulting archives to a Hugging Face dataset repository.
+
+Example usage:
+
+    python pack_and_upload_dataset.py \
+        --dataset-root ./workspace/d23/d23 \
+        --output-dir ./workspace/d23_archives \
+        --repo-id username/dataset-name \
+        --max-files-per-archive 50000 \
+        --max-archive-bytes 3221225472 \
+        --commit-message "Add compressed dataset shards"
+
+Environment variables:
+    HF_TOKEN (optional) - fallback Hugging Face token if --hf-token is omitted
+"""
+
+import argparse
+import os
+import shutil
+import tarfile
+from pathlib import Path
+from typing import Iterable, List, NamedTuple, Optional, Sequence
+
+from huggingface_hub import HfApi, HfFolder
+from tqdm import tqdm
+
+
+IMAGE_EXTENSIONS = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".bmp",
+    ".webp",
+    ".gif",
+    ".tiff",
+    ".tif",
+}
+
+
+class ArchivingConfig(NamedTuple):
+    dataset_root: Path
+    output_dir: Path
+    repo_id: str
+    repo_revision: str
+    commit_message: str
+    archive_prefix: str
+    max_files_per_archive: int
+    max_archive_bytes: Optional[int]
+    compress_level: int
+    include_extensions: Sequence[str]
+    follow_symlinks: bool
+    overwrite_output: bool
+    make_private: bool
+    hf_token: str
+
+
+def parse_args() -> ArchivingConfig:
+    parser = argparse.ArgumentParser(description="Pack dataset shards and upload to Hugging Face")
+    parser.add_argument(
+        "--dataset-root",
+        type=Path,
+        default=Path("./workspace/d23/d23"),
+        help="Root directory containing the full dataset",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("./workspace/d23_archives"),
+        help="Destination directory where tar.gz archives will be written",
+    )
+    parser.add_argument(
+        "--repo-id",
+        required=True,
+        help="Hugging Face dataset repository id (e.g. username/dataset-name)",
+    )
+    parser.add_argument(
+        "--repo-revision",
+        default="main",
+        help="Target branch or tag on the Hugging Face repo (default: main)",
+    )
+    parser.add_argument(
+        "--commit-message",
+        default="Add compressed dataset archives",
+        help="Commit message used for the upload",
+    )
+    parser.add_argument(
+        "--archive-prefix",
+        default="dataset_part",
+        help="Filename prefix for generated archives",
+    )
+    parser.add_argument(
+        "--max-files-per-archive",
+        type=int,
+        default=50_000,
+        help="Maximum number of files packed into a single archive",
+    )
+    parser.add_argument(
+        "--max-archive-bytes",
+        type=int,
+        default=3 * 1024 * 1024 * 1024,
+        help="Maximum (approximate) uncompressed bytes per archive; set 0 to disable",
+    )
+    parser.add_argument(
+        "--compress-level",
+        type=int,
+        choices=range(1, 10),
+        default=9,
+        help="gzip compression level (1=fastest, 9=smallest)",
+    )
+    parser.add_argument(
+        "--extensions",
+        nargs="*",
+        default=None,
+        help="Optional list of file extensions to include (defaults to common image types)",
+    )
+    parser.add_argument(
+        "--follow-symlinks",
+        action="store_true",
+        help="Follow symbolic links when discovering files",
+    )
+    parser.add_argument(
+        "--overwrite-output",
+        action="store_true",
+        help="Delete existing output directory before writing archives",
+    )
+    parser.add_argument(
+        "--private",
+        action="store_true",
+        help="Create the Hugging Face dataset repository as private",
+    )
+    parser.add_argument(
+        "--hf-token",
+        default=None,
+        help="Explicit Hugging Face token (otherwise uses HF_TOKEN or cached login)",
+    )
+
+    args = parser.parse_args()
+
+    dataset_root = args.dataset_root.expanduser().resolve()
+    output_dir = args.output_dir.expanduser().resolve()
+
+    if not dataset_root.exists() or not dataset_root.is_dir():
+        raise FileNotFoundError(f"Dataset root {dataset_root} not found or is not a directory")
+
+    extensions = [ext.lower() if ext.startswith(".") else f".{ext.lower()}" for ext in (args.extensions or IMAGE_EXTENSIONS)]
+
+    token = (
+        args.hf_token
+        or os.getenv("HF_TOKEN")
+        or HfFolder().get_token()
+    )
+
+    if not token:
+        raise RuntimeError("No Hugging Face token provided. Use --hf-token or set HF_TOKEN.")
+
+    max_archive_bytes = args.max_archive_bytes if args.max_archive_bytes > 0 else None
+
+    return ArchivingConfig(
+        dataset_root=dataset_root,
+        output_dir=output_dir,
+        repo_id=args.repo_id,
+        repo_revision=args.repo_revision,
+        commit_message=args.commit_message,
+        archive_prefix=args.archive_prefix,
+        max_files_per_archive=args.max_files_per_archive,
+        max_archive_bytes=max_archive_bytes,
+        compress_level=args.compress_level,
+        include_extensions=extensions,
+        follow_symlinks=args.follow_symlinks,
+        overwrite_output=args.overwrite_output,
+        make_private=args.private,
+        hf_token=token,
+    )
+
+
+def discover_files(root: Path, extensions: Sequence[str], follow_symlinks: bool) -> List[Path]:
+    candidates: List[Path] = []
+    for path in root.rglob("*"):
+        if not follow_symlinks and path.is_symlink():
+            continue
+        if path.is_file() and path.suffix.lower() in extensions:
+            candidates.append(path)
+    if not candidates:
+        raise RuntimeError(f"No files with extensions {extensions} found under {root}")
+    return candidates
+
+
+def ensure_output_dir(config: ArchivingConfig) -> None:
+    if config.output_dir.exists():
+        if not config.overwrite_output and any(config.output_dir.iterdir()):
+            raise FileExistsError(
+                f"Output directory {config.output_dir} exists and is not empty."
+                " Use --overwrite-output to replace it."
+            )
+        if config.overwrite_output:
+            shutil.rmtree(config.output_dir)
+            config.output_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        config.output_dir.mkdir(parents=True, exist_ok=True)
+
+
+def chunk_files(
+    files: Sequence[Path],
+    max_files: int,
+    max_bytes: Optional[int],
+) -> Iterable[Sequence[Path]]:
+    if max_files <= 0:
+        raise ValueError("max_files_per_archive must be positive")
+
+    current: List[Path] = []
+    current_bytes = 0
+
+    for file_path in files:
+        file_size = file_path.stat().st_size
+        if current and (
+            len(current) >= max_files
+            or (max_bytes is not None and current_bytes + file_size > max_bytes)
+        ):
+            yield current
+            current = []
+            current_bytes = 0
+
+        current.append(file_path)
+        current_bytes += file_size
+
+    if current:
+        yield current
+
+
+def create_archives(config: ArchivingConfig, files: Sequence[Path]) -> List[Path]:
+    archives: List[Path] = []
+    file_progress = tqdm(total=len(files), desc="Archiving", unit="file")
+
+    for index, batch in enumerate(
+        chunk_files(files, config.max_files_per_archive, config.max_archive_bytes),
+        start=1,
+    ):
+        archive_path = config.output_dir / f"{config.archive_prefix}_{index:04d}.tar.gz"
+        with tarfile.open(archive_path, mode="w:gz", compresslevel=config.compress_level) as tar:
+            for src in batch:
+                arcname = src.relative_to(config.dataset_root)
+                tar.add(str(src), arcname=arcname.as_posix())
+                file_progress.update(1)
+
+        archives.append(archive_path)
+
+    file_progress.close()
+    return archives
+
+
+def upload_archives(config: ArchivingConfig, archives_dir: Path) -> None:
+    api = HfApi(token=config.hf_token)
+    api.create_repo(repo_id=config.repo_id, repo_type="dataset", private=config.make_private, exist_ok=True)
+
+    tqdm.write("Uploading archives to Hugging Face…")
+    api.upload_folder(
+        folder_path=str(archives_dir),
+        repo_id=config.repo_id,
+        repo_type="dataset",
+        revision=config.repo_revision,
+        token=config.hf_token,
+        commit_message=config.commit_message,
+        allow_patterns=["*.tar.gz"],
+    )
+
+
+def main() -> None:
+    config = parse_args()
+
+    print(f"Dataset root: {config.dataset_root}")
+    print(f"Output directory: {config.output_dir}")
+    print(f"Target repository: {config.repo_id} ({'private' if config.make_private else 'public'})")
+
+    ensure_output_dir(config)
+
+    files = discover_files(config.dataset_root, config.include_extensions, config.follow_symlinks)
+    print(f"Discovered {len(files)} files to archive.")
+
+    archives = create_archives(config, files)
+    print(f"Created {len(archives)} archives:")
+    for archive in archives:
+        size_mb = archive.stat().st_size / (1024 * 1024)
+        print(f" - {archive.name} ({size_mb:.2f} MiB)")
+
+    upload_archives(config, config.output_dir)
+    print("Upload completed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/train_core.py
+++ b/training/train_core.py
@@ -405,6 +405,9 @@ class LatentUpscalerConfig:
     enabled: bool
     width_multiplier: int
     scale_factor: Optional[int]
+    rrdb_blocks: int
+    growth_channels: int
+    residual_scaling: float
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "LatentUpscalerConfig":
@@ -414,6 +417,9 @@ class LatentUpscalerConfig:
             enabled=bool(section.get("enabled", data.get("train_latent_upscaler", False))),
             width_multiplier=int(section.get("width_multiplier", data.get("latent_upscaler_width", 2))),
             scale_factor=int(scale) if scale is not None else None,
+            rrdb_blocks=int(section.get("rrdb_blocks", section.get("num_blocks", 6))),
+            growth_channels=int(section.get("growth_channels", 32)),
+            residual_scaling=float(section.get("residual_scaling", 0.2)),
         )
 
 
@@ -588,20 +594,76 @@ class ImageFolderDataset(Dataset):
 # Helper modules
 
 
+class ResidualDenseBlock(nn.Module):
+    def __init__(self, channels: int, growth_channels: int, residual_scaling: float) -> None:
+        super().__init__()
+        self.residual_scaling = residual_scaling
+        self.conv1 = nn.Conv2d(channels, growth_channels, kernel_size=3, padding=1)
+        self.conv2 = nn.Conv2d(channels + growth_channels, growth_channels, kernel_size=3, padding=1)
+        self.conv3 = nn.Conv2d(channels + 2 * growth_channels, growth_channels, kernel_size=3, padding=1)
+        self.conv4 = nn.Conv2d(channels + 3 * growth_channels, growth_channels, kernel_size=3, padding=1)
+        self.conv5 = nn.Conv2d(channels + 4 * growth_channels, channels, kernel_size=3, padding=1)
+        self.act = nn.LeakyReLU(negative_slope=0.2, inplace=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x1 = self.act(self.conv1(x))
+        x2 = self.act(self.conv2(torch.cat((x, x1), dim=1)))
+        x3 = self.act(self.conv3(torch.cat((x, x1, x2), dim=1)))
+        x4 = self.act(self.conv4(torch.cat((x, x1, x2, x3), dim=1)))
+        x5 = self.conv5(torch.cat((x, x1, x2, x3, x4), dim=1))
+        return x + x5 * self.residual_scaling
+
+
+class ResidualInResidualDenseBlock(nn.Module):
+    def __init__(self, channels: int, growth_channels: int, residual_scaling: float) -> None:
+        super().__init__()
+        self.rdb1 = ResidualDenseBlock(channels, growth_channels, residual_scaling)
+        self.rdb2 = ResidualDenseBlock(channels, growth_channels, residual_scaling)
+        self.rdb3 = ResidualDenseBlock(channels, growth_channels, residual_scaling)
+        self.residual_scaling = residual_scaling
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.rdb1(x)
+        out = self.rdb2(out)
+        out = self.rdb3(out)
+        return out * self.residual_scaling + x
+
+
 class LatentUpscaler(nn.Module):
-    def __init__(self, channels: int, scale_factor: int, hidden_multiplier: int) -> None:
+    def __init__(
+        self,
+        channels: int,
+        scale_factor: int,
+        hidden_multiplier: int,
+        num_blocks: int,
+        growth_channels: int,
+        residual_scaling: float,
+    ) -> None:
         super().__init__()
         if scale_factor < 2:
             raise ValueError("Latent upscaler requires scale_factor >= 2")
         hidden_channels = max(channels * hidden_multiplier, channels)
+        growth_channels = max(1, growth_channels)
+        residual_scaling = float(residual_scaling)
         self.scale_factor = scale_factor
-        self.net = nn.Sequential(
-            nn.Conv2d(channels, hidden_channels, kernel_size=3, padding=1),
-            nn.SiLU(inplace=True),
-            nn.Conv2d(hidden_channels, channels * (scale_factor ** 2), kernel_size=3, padding=1),
-            nn.SiLU(inplace=True),
+        body_blocks = [
+            ResidualInResidualDenseBlock(
+                hidden_channels,
+                growth_channels,
+                residual_scaling,
+            )
+            for _ in range(max(1, num_blocks))
+        ]
+        self.trunk = nn.Sequential(*body_blocks)
+        self.conv_first = nn.Conv2d(channels, hidden_channels, kernel_size=3, padding=1)
+        self.conv_trunk = nn.Conv2d(hidden_channels, hidden_channels, kernel_size=3, padding=1)
+        self.upsample = nn.Sequential(
+            nn.Conv2d(hidden_channels, hidden_channels * (scale_factor ** 2), kernel_size=3, padding=1),
             nn.PixelShuffle(scale_factor),
-            nn.Conv2d(channels, channels, kernel_size=3, padding=1),
+            nn.LeakyReLU(negative_slope=0.2, inplace=True),
+            nn.Conv2d(hidden_channels, hidden_channels, kernel_size=3, padding=1),
+            nn.SiLU(inplace=True),
+            nn.Conv2d(hidden_channels, channels, kernel_size=3, padding=1),
         )
         self.act = nn.SiLU(inplace=True)
 
@@ -619,7 +681,10 @@ class LatentUpscaler(nn.Module):
 
     def _forward_2d(self, latents: torch.Tensor) -> torch.Tensor:
         residual = F.interpolate(latents, scale_factor=self.scale_factor, mode="nearest")
-        out = self.net(latents)
+        features = self.conv_first(latents)
+        trunk_out = self.conv_trunk(self.trunk(features))
+        features = features + trunk_out
+        out = self.upsample(features)
         return self.act(out + residual.to(out.dtype))
 
 
@@ -1011,7 +1076,14 @@ class VAETrainer:
         latent_channels = self._determine_latent_channels(vae)
         if latent_channels is None:
             raise RuntimeError("Unable to determine latent channels for upscaler")
-        upscaler = LatentUpscaler(latent_channels, scale_factor=scale_factor, hidden_multiplier=cfg.latent_upscaler.width_multiplier)
+        upscaler = LatentUpscaler(
+            latent_channels,
+            scale_factor=scale_factor,
+            hidden_multiplier=cfg.latent_upscaler.width_multiplier,
+            num_blocks=cfg.latent_upscaler.rrdb_blocks,
+            growth_channels=cfg.latent_upscaler.growth_channels,
+            residual_scaling=cfg.latent_upscaler.residual_scaling,
+        )
         return upscaler.to(self.device, dtype=self.cfg.model.dtype)
 
     def _freeze_parameters(self) -> None:

--- a/training/train_core.py
+++ b/training/train_core.py
@@ -39,6 +39,7 @@ from torch import nn
 from torch.optim.lr_scheduler import CosineAnnealingLR, LambdaLR
 from torch.optim.swa_utils import AveragedModel
 from torch.utils.data import DataLoader, Dataset
+from torch.nn.utils import spectral_norm as apply_spectral_norm
 from tqdm import tqdm
 
 
@@ -143,6 +144,7 @@ class DatasetConfig:
     limit: int
     num_workers: int
     horizontal_flip_prob: float
+    persistent_workers: bool
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "DatasetConfig":
@@ -154,6 +156,9 @@ class DatasetConfig:
             limit=int(section.get("limit", data.get("limit", 0))),
             num_workers=int(section.get("num_workers", data.get("num_workers", 4))),
             horizontal_flip_prob=float(section.get("horizontal_flip_prob", data.get("horizontal_flip_prob", 0.0))),
+            persistent_workers=_resolve_bool(
+                section.get("persistent_workers", data.get("persistent_workers", True))
+            ),
         )
 
 
@@ -296,6 +301,7 @@ class LossConfig:
             "lpips": 0.0,
             "kl": default_kl,
             "ffl": 0.0,
+            "adv": 0.0,
         }
 
         def resolve_ratio(name: str, default: float) -> float:
@@ -412,6 +418,44 @@ class LatentUpscalerConfig:
 
 
 @dataclass
+class AdversarialConfig:
+    enabled: bool
+    loss_type: str
+    discriminator_channels: int
+    discriminator_max_channels: int
+    discriminator_layers: int
+    discriminator_norm: str
+    spectral_norm: bool
+    lr: float
+    beta1: float
+    beta2: float
+    weight_decay: float
+    clip_grad_norm: float
+    update_frequency: int
+    warmup_steps: int
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AdversarialConfig":
+        section = data.get("adversarial", {})
+        return cls(
+            enabled=_resolve_bool(section.get("enabled", data.get("adversarial_enabled", False))),
+            loss_type=str(section.get("loss_type", data.get("adversarial_loss", "ragan"))).lower(),
+            discriminator_channels=int(section.get("discriminator", {}).get("base_channels", 64)),
+            discriminator_max_channels=int(section.get("discriminator", {}).get("max_channels", 512)),
+            discriminator_layers=int(section.get("discriminator", {}).get("num_layers", 4)),
+            discriminator_norm=str(section.get("discriminator", {}).get("norm", "instance")).lower(),
+            spectral_norm=_resolve_bool(section.get("discriminator", {}).get("spectral_norm", True)),
+            lr=float(section.get("optimizer", {}).get("lr", section.get("lr", 1e-4))),
+            beta1=float(section.get("optimizer", {}).get("beta1", 0.9)),
+            beta2=float(section.get("optimizer", {}).get("beta2", 0.99)),
+            weight_decay=float(section.get("optimizer", {}).get("weight_decay", 0.0)),
+            clip_grad_norm=float(section.get("optimizer", {}).get("clip_grad_norm", 1.0)),
+            update_frequency=int(section.get("update_frequency", 1)),
+            warmup_steps=int(section.get("warmup_steps", 0)),
+        )
+
+
+@dataclass
 class TrainingConfig:
     paths: PathsConfig
     dataset: DatasetConfig
@@ -421,6 +465,7 @@ class TrainingConfig:
     logging: LoggingConfig
     latent_upscaler: LatentUpscalerConfig
     ema: EMAConfig
+    adversarial: AdversarialConfig
     seed: int
 
     @classmethod
@@ -433,6 +478,7 @@ class TrainingConfig:
         logging = LoggingConfig.from_dict(data, timestamp=paths.timestamp)
         latent_upscaler = LatentUpscalerConfig.from_dict(data)
         ema = EMAConfig.from_dict(data)
+        adversarial = AdversarialConfig.from_dict(data)
         seed = int(data.get("seed", int(datetime.now().strftime("%Y%m%d"))))
         return cls(
             paths=paths,
@@ -443,6 +489,7 @@ class TrainingConfig:
             logging=logging,
             latent_upscaler=latent_upscaler,
             ema=ema,
+            adversarial=adversarial,
             seed=seed,
         )
 
@@ -642,6 +689,66 @@ class FocalFrequencyLoss(nn.Module):
         return loss_matrix.sum() / loss_matrix.numel()
 
 
+class PatchDiscriminator(nn.Module):
+    def __init__(
+        self,
+        in_channels: int = 3,
+        base_channels: int = 64,
+        max_channels: int = 512,
+        num_layers: int = 4,
+        norm: str = "instance",
+        use_spectral_norm: bool = True,
+    ) -> None:
+        super().__init__()
+        layers: List[nn.Module] = []
+        current_in = in_channels
+        current_out = base_channels
+        norm = norm.lower()
+
+        for layer_idx in range(max(1, num_layers)):
+            stride = 1 if layer_idx == 0 else 2
+            conv = nn.Conv2d(current_in, current_out, kernel_size=3, stride=stride, padding=1)
+            if use_spectral_norm:
+                conv = apply_spectral_norm(conv)
+            block: List[nn.Module] = [conv]
+            if norm == "instance":
+                block.append(nn.InstanceNorm2d(current_out))
+            elif norm == "layer":
+                block.append(nn.GroupNorm(1, current_out))
+            block.append(nn.LeakyReLU(0.2, inplace=True))
+            layers.append(nn.Sequential(*block))
+            current_in = current_out
+            current_out = min(current_out * 2, max_channels)
+
+        final = nn.Conv2d(current_in, 1, kernel_size=3, padding=1)
+        if use_spectral_norm:
+            final = apply_spectral_norm(final)
+        layers.append(final)
+        self.net = nn.Sequential(*layers)
+
+    def forward(self, images: torch.Tensor) -> torch.Tensor:
+        return self.net(images)
+
+
+class RaGANLoss:
+    def __init__(self) -> None:
+        self.criterion = nn.BCEWithLogitsLoss()
+
+    def discriminator_loss(self, real_pred: torch.Tensor, fake_pred: torch.Tensor) -> torch.Tensor:
+        real_labels = torch.ones_like(real_pred)
+        fake_labels = torch.zeros_like(fake_pred)
+        loss_real = self.criterion(real_pred - fake_pred.mean(), real_labels)
+        loss_fake = self.criterion(fake_pred - real_pred.mean(), fake_labels)
+        return 0.5 * (loss_real + loss_fake)
+
+    def generator_loss(self, real_pred: torch.Tensor, fake_pred: torch.Tensor) -> torch.Tensor:
+        real_labels = torch.zeros_like(real_pred)
+        fake_labels = torch.ones_like(fake_pred)
+        loss_fake = self.criterion(fake_pred - real_pred.mean(), fake_labels)
+        loss_real = self.criterion(real_pred - fake_pred.mean(), real_labels)
+        return 0.5 * (loss_fake + loss_real)
+
+
 # ---------------------------------------------------------------------------
 # Trainer implementation
 
@@ -650,6 +757,8 @@ class VAETrainer:
     def __init__(self, config: TrainingConfig) -> None:
         self.cfg = config
         self.cfg.paths.ensure_directories()
+
+        torch.backends.cudnn.benchmark = True
 
         self.accelerator = Accelerator(
             mixed_precision=config.model.mixed_precision,
@@ -670,6 +779,7 @@ class VAETrainer:
                 f"Found only {len(self.dataset)} images but batch_size is {self.cfg.optimiser.batch_size}."
             )
 
+        persistent_workers = self.cfg.dataset.persistent_workers and self.cfg.dataset.num_workers > 0
         self.dataloader = DataLoader(
             self.dataset,
             batch_size=self.cfg.optimiser.batch_size,
@@ -677,11 +787,34 @@ class VAETrainer:
             drop_last=True,
             num_workers=self.cfg.dataset.num_workers,
             pin_memory=True,
+            persistent_workers=persistent_workers,
         )
 
         self.vae = self._load_vae()
         self.latent_upscaler: Optional[LatentUpscaler] = self._build_latent_upscaler(self.vae)
         self._freeze_parameters()
+
+        self.discriminator: Optional[PatchDiscriminator] = None
+        self.discriminator_optimizer: Optional[torch.optim.Optimizer] = None
+        self.adversarial_loss: Optional[RaGANLoss] = None
+
+        adv_ratio = self.cfg.losses.ratios.get("adv", 0.0)
+        self.adv_active = self.cfg.adversarial.enabled and adv_ratio > 0.0
+        if adv_ratio > 0.0 and not self.cfg.adversarial.enabled:
+            self.accelerator.print(
+                "[WARN] Adversarial loss ratio set but adversarial training disabled; ignoring adversarial loss"
+            )
+        if not self.adv_active and "adv" in self.cfg.losses.ratios:
+            self.cfg.losses.ratios.pop("adv")
+            self.cfg.losses.enabled["adv"] = False
+            self.cfg.losses.active_losses = tuple(
+                key for key in self.cfg.losses.active_losses if key != "adv"
+            )
+
+        if self.adv_active:
+            self.discriminator = self._build_discriminator()
+            self.adversarial_loss = self._build_adversarial_loss()
+            self.discriminator_optimizer = self._build_discriminator_optimizer()
 
         self.optimizer = self._build_optimizer()
         self.scheduler = self._build_scheduler()
@@ -689,15 +822,23 @@ class VAETrainer:
         prepare_items: List[Any] = [self.dataloader, self.vae]
         if self.latent_upscaler is not None:
             prepare_items.append(self.latent_upscaler)
+        if self.discriminator is not None:
+            prepare_items.append(self.discriminator)
         prepare_items.extend([self.optimizer, self.scheduler])
+        if self.discriminator_optimizer is not None:
+            prepare_items.append(self.discriminator_optimizer)
         prepared = self.accelerator.prepare(*prepare_items)
-        iterator = iter(prepared)
-        self.dataloader = next(iterator)
-        self.vae = next(iterator)
+        idx = 0
+        self.dataloader = prepared[idx]; idx += 1
+        self.vae = prepared[idx]; idx += 1
         if self.latent_upscaler is not None:
-            self.latent_upscaler = next(iterator)
-        self.optimizer = next(iterator)
-        self.scheduler = next(iterator)
+            self.latent_upscaler = prepared[idx]; idx += 1
+        if self.discriminator is not None:
+            self.discriminator = prepared[idx]; idx += 1
+        self.optimizer = prepared[idx]; idx += 1
+        self.scheduler = prepared[idx]; idx += 1
+        if self.discriminator_optimizer is not None:
+            self.discriminator_optimizer = prepared[idx]
 
         self.compile_enabled = False
         if self.cfg.model.use_torch_compile and hasattr(torch, "compile"):
@@ -721,6 +862,8 @@ class VAETrainer:
         self.trainable_params = [p for p in self.vae.parameters() if p.requires_grad]
         if self.latent_upscaler is not None:
             self.trainable_params.extend(p for p in self.latent_upscaler.parameters() if p.requires_grad)
+        if self.discriminator is not None:
+            self.discriminator_optimizer.zero_grad(set_to_none=True)
 
         self.loss_normalizer = MedianLossNormalizer(
             self.cfg.losses.ratios,
@@ -744,6 +887,8 @@ class VAETrainer:
             self.lpips_module = self.lpips_module.to(self.device).eval()
             for p in self.lpips_module.parameters():
                 p.requires_grad_(False)
+
+        self.discriminator_steps = 0
 
         self.ema_vae: Optional[AveragedModel] = None
         self.ema_latent_upscaler: Optional[AveragedModel] = None
@@ -946,6 +1091,35 @@ class VAETrainer:
             )
         raise ValueError(f"Unsupported optimizer type: {self.cfg.optimiser.optimizer_type}")
 
+    def _build_discriminator(self) -> PatchDiscriminator:
+        cfg = self.cfg.adversarial
+        return PatchDiscriminator(
+            in_channels=3,
+            base_channels=cfg.discriminator_channels,
+            max_channels=cfg.discriminator_max_channels,
+            num_layers=cfg.discriminator_layers,
+            norm=cfg.discriminator_norm,
+            use_spectral_norm=cfg.spectral_norm,
+        )
+
+    def _build_discriminator_optimizer(self) -> torch.optim.Optimizer:
+        if self.discriminator is None:
+            raise RuntimeError("Discriminator not initialised")
+        cfg = self.cfg.adversarial
+        return torch.optim.Adam(
+            self.discriminator.parameters(),
+            lr=cfg.lr,
+            betas=(cfg.beta1, cfg.beta2),
+            weight_decay=cfg.weight_decay,
+        )
+
+    def _build_adversarial_loss(self) -> RaGANLoss:
+        if self.cfg.adversarial.loss_type not in {"ragan", "relativistic", "relativistic-average"}:
+            raise ValueError(
+                f"Unsupported adversarial loss type '{self.cfg.adversarial.loss_type}'. Only 'ragan' is implemented."
+            )
+        return RaGANLoss()
+
     def _total_steps(self) -> int:
         batches_per_epoch = len(self.dataloader)
         effective_batches = batches_per_epoch / max(1, self.cfg.optimiser.gradient_accumulation_steps)
@@ -973,6 +1147,49 @@ class VAETrainer:
             return max(min_ratio, 0.5 * (1.0 + math.cos(math.pi * progress)))
 
         return LambdaLR(self.optimizer, schedule)
+
+    def _toggle_discriminator_grad(self, enabled: bool) -> None:
+        if self.discriminator is None:
+            return
+        for param in self.discriminator.parameters():
+            param.requires_grad_(enabled)
+
+    def _should_train_discriminator(self) -> bool:
+        frequency = max(1, self.cfg.adversarial.update_frequency)
+        return self.discriminator_steps % frequency == 0
+
+    def _discriminator_step(self, real_images: torch.Tensor, fake_images: torch.Tensor) -> Tuple[Optional[float], Optional[float]]:
+        if self.discriminator is None or self.discriminator_optimizer is None or self.adversarial_loss is None:
+            return None, None
+        self._toggle_discriminator_grad(True)
+        disc_loss_value: Optional[float] = None
+        grad_norm_value: Optional[float] = None
+        with self.accelerator.accumulate(self.discriminator):
+            real_pred = self.discriminator(real_images.to(torch.float32))
+            fake_pred = self.discriminator(fake_images.to(torch.float32))
+            loss = self.adversarial_loss.discriminator_loss(real_pred, fake_pred)
+            self.accelerator.backward(loss)
+            disc_loss_value = float(loss.detach().item())
+            grad_norm = torch.tensor(0.0, device=self.device)
+            if self.accelerator.sync_gradients:
+                if self.cfg.adversarial.clip_grad_norm > 0:
+                    grad_norm = self.accelerator.clip_grad_norm_(
+                        self.discriminator.parameters(), self.cfg.adversarial.clip_grad_norm
+                    )
+                self.discriminator_optimizer.step()
+                self.discriminator_optimizer.zero_grad(set_to_none=True)
+                grad_norm_value = float(grad_norm.detach().item()) if isinstance(grad_norm, torch.Tensor) else 0.0
+        return disc_loss_value, grad_norm_value
+
+    def _generator_adversarial_loss(self, real_images: torch.Tensor, fake_images: torch.Tensor) -> torch.Tensor:
+        if self.discriminator is None or self.adversarial_loss is None:
+            return torch.zeros((), device=self.device)
+        self._toggle_discriminator_grad(False)
+        with torch.no_grad():
+            real_pred = self.discriminator(real_images.to(torch.float32))
+        fake_pred = self.discriminator(fake_images.to(torch.float32))
+        loss = self.adversarial_loss.generator_loss(real_pred.detach(), fake_pred)
+        return loss
 
     def _update_ema(self, step: int) -> None:
         if self.ema_vae is None:
@@ -1006,6 +1223,8 @@ class VAETrainer:
             "full_training": cfg.model.full_training,
             "vae_kind": cfg.model.vae_kind,
             "latent_upscaler_enabled": cfg.latent_upscaler.enabled,
+            "adversarial_enabled": self.adv_active,
+            "adversarial_loss_type": cfg.adversarial.loss_type,
         }
 
     # ---------------------------------------------------------------- training
@@ -1023,17 +1242,35 @@ class VAETrainer:
             self.vae.train()
             if self.latent_upscaler is not None:
                 self.latent_upscaler.train()
+            if self.discriminator is not None:
+                self.discriminator.train()
             batch_losses: List[float] = []
             batch_grads: List[float] = []
+            disc_losses: List[float] = []
+            disc_grads: List[float] = []
 
             for batch in self.dataloader:
-                with self.accelerator.accumulate(self.vae):
-                    batch = batch.to(self.device)
-                    low_res = self._downsample_for_model(batch)
-                    reconstruction, encode_out = self._forward(latents_input=low_res)
-                    reconstruction = self._match_spatial(reconstruction, batch)
+                batch = batch.to(self.device)
+                low_res = self._downsample_for_model(batch)
+                reconstruction, encode_out = self._forward(latents_input=low_res)
+                reconstruction = self._match_spatial(reconstruction, batch)
 
+                disc_loss_value = None
+                disc_grad_value = None
+                if (
+                    self.adv_active
+                    and self.discriminator is not None
+                    and global_step >= self.cfg.adversarial.warmup_steps
+                    and self._should_train_discriminator()
+                ):
+                    disc_loss_value, disc_grad_value = self._discriminator_step(
+                        batch, reconstruction.detach()
+                    )
+
+                with self.accelerator.accumulate(self.vae):
                     losses = self._compute_losses(reconstruction, batch, encode_out)
+                    if self.adv_active and global_step >= self.cfg.adversarial.warmup_steps:
+                        losses["adv"] = self._generator_adversarial_loss(batch, reconstruction)
                     total_loss, coeffs, medians = self.loss_normalizer.update(losses)
                     if not torch.isfinite(total_loss):
                         raise RuntimeError("Encountered NaN/Inf loss")
@@ -1043,7 +1280,9 @@ class VAETrainer:
                     grad_norm = torch.tensor(0.0, device=self.device)
                     if self.accelerator.sync_gradients:
                         if self.cfg.optimiser.clip_grad_norm > 0:
-                            grad_norm = self.accelerator.clip_grad_norm_(self.trainable_params, self.cfg.optimiser.clip_grad_norm)
+                            grad_norm = self.accelerator.clip_grad_norm_(
+                                self.trainable_params, self.cfg.optimiser.clip_grad_norm
+                            )
                         self.optimizer.step()
                         self.scheduler.step()
                         self.optimizer.zero_grad(set_to_none=True)
@@ -1055,6 +1294,9 @@ class VAETrainer:
                         lr = self.optimizer.param_groups[0]["lr"]
                         batch_losses.append(float(total_loss.detach().item()))
                         batch_grads.append(float(grad_norm.detach().item()) if isinstance(grad_norm, torch.Tensor) else 0.0)
+                        if disc_loss_value is not None:
+                            disc_losses.append(disc_loss_value)
+                            disc_grads.append(disc_grad_value or 0.0)
                         if self.cfg.logging.use_wandb and self.accelerator.sync_gradients:
                             log = {
                                 "total_loss": float(total_loss.detach().item()),
@@ -1063,11 +1305,15 @@ class VAETrainer:
                             }
                             if self.cfg.logging.log_grad_norm:
                                 log["grad_norm"] = batch_grads[-1]
+                                if disc_loss_value is not None:
+                                    log["grad_norm_discriminator"] = disc_grad_value or 0.0
                             for key, value in losses.items():
                                 log[f"loss_{key}"] = float(value.detach().item())
                             for key, value in coeffs.items():
                                 log[f"coeff_{key}"] = float(value)
                                 log[f"median_{key}"] = float(medians.get(key, 0.0))
+                            if disc_loss_value is not None:
+                                log["loss_discriminator"] = disc_loss_value
                             wandb.log(log, step=global_step)
 
                     if (
@@ -1099,6 +1345,9 @@ class VAETrainer:
                                 self._save_best_checkpoint(best_loss, best_step)
                             if self.cfg.logging.use_wandb:
                                 wandb.log({"interm_loss": avg_loss, "interm_grad": avg_grad}, step=global_step)
+
+                if self.adv_active:
+                    self.discriminator_steps += 1
 
             if self.accelerator.is_main_process:
                 epoch_loss = float(np.mean(batch_losses)) if batch_losses else float("nan")


### PR DESCRIPTION
## Summary
- remove the adversarial configuration structures and training paths from the shared VAE trainer
- simplify loss handling to reconstruction-focused objectives and drop discriminator utilities
- update the sample configuration to exclude adversarial-specific options

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e27a23720083218fe881df6988e481