### PR TITLE
Simplify embedding cache to single variant per image

### DIFF
--- a/configs/embeddings_precompute.yaml
+++ b/configs/embeddings_precompute.yaml
@@ -3,7 +3,6 @@ dataset_root: ./unpacked_original_ds/full_dataset
 cache_root: cache_vae_embeddings
 
 defaults:
-  variants_per_sample: 1
   num_workers: 6
   embeddings_dtype: float32
   store_distribution: true

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -91,7 +91,6 @@ embeddings:
   enabled: true
   cache_dir: ./cache_vae_embeddings
   dtype: float16
-  variants_per_sample: 2
   overwrite: false
   precompute_batch_size: 64
   precompute_num_workers: 4

--- a/training/config.py
+++ b/training/config.py
@@ -361,7 +361,6 @@ class EmbeddingsConfig:
     enabled: bool
     cache_dir: Path
     dtype: torch.dtype
-    variants_per_sample: int
     overwrite: bool
     precompute_batch_size: int
     num_workers: int
@@ -378,7 +377,6 @@ class EmbeddingsConfig:
         if not cache_dir.is_absolute():
             cache_dir = (dataset_root / cache_dir).resolve()
         dtype = _resolve_dtype(section.get("dtype", data.get("embeddings_dtype", "float16")))
-        variants = int(section.get("variants_per_sample", data.get("embeddings_variants", 1)))
         overwrite = _resolve_bool(section.get("overwrite", data.get("embeddings_overwrite", False)))
         precompute_batch_size = int(
             section.get("precompute_batch_size", data.get("embeddings_precompute_batch_size", 16))
@@ -400,7 +398,6 @@ class EmbeddingsConfig:
             enabled=enabled,
             cache_dir=cache_dir,
             dtype=dtype,
-            variants_per_sample=max(1, variants),
             overwrite=overwrite,
             precompute_batch_size=max(1, precompute_batch_size),
             num_workers=max(0, num_workers),

--- a/training/multi_precompute_config.py
+++ b/training/multi_precompute_config.py
@@ -89,7 +89,6 @@ class ResolutionSpec:
 @dataclass
 class MultiPrecomputeDefaults:
     cache_subdir: str = "cache_embeddings"
-    variants_per_sample: int = 1
     batch_size: int = 16
     num_workers: int = 4
     resize_long_side: Optional[int] = None
@@ -103,7 +102,6 @@ class MultiPrecomputeDefaults:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "MultiPrecomputeDefaults":
         cache_subdir = str(data.get("cache_subdir", "cache_embeddings"))
-        variants = int(data.get("variants_per_sample", 1))
         batch = int(data.get("batch_size", 16))
         workers = int(data.get("num_workers", 4))
         resize = data.get("resize_long_side")
@@ -139,7 +137,6 @@ class MultiPrecomputeDefaults:
 
         return cls(
             cache_subdir=cache_subdir,
-            variants_per_sample=max(1, variants),
             batch_size=max(1, batch),
             num_workers=max(0, workers),
             resize_long_side=int(resize) if resize is not None else None,
@@ -167,7 +164,6 @@ class MultiVaeConfig:
     dataset_root: Optional[Path]
     dataset_subdir: Optional[Path]
     cache_subdir: Optional[Path]
-    variants_per_sample: Optional[int]
     batch_size: Optional[int]
     num_workers: Optional[int]
     resize_long_side: Optional[int]
@@ -198,7 +194,6 @@ class MultiVaeConfig:
         cache_subdir = data.get("cache_subdir")
         weights_dtype = data.get("weights_dtype")
         embeddings_dtype = data.get("embeddings_dtype")
-        variants = data.get("variants_per_sample")
         batch = data.get("batch_size")
         workers = data.get("num_workers")
         resize = data.get("resize_long_side")
@@ -227,7 +222,6 @@ class MultiVaeConfig:
             dataset_root=Path(dataset_root).expanduser() if dataset_root else None,
             dataset_subdir=Path(dataset_subdir).expanduser() if dataset_subdir else None,
             cache_subdir=Path(cache_subdir).expanduser() if cache_subdir else None,
-            variants_per_sample=int(variants) if variants is not None else None,
             batch_size=int(batch) if batch is not None else None,
             num_workers=int(workers) if workers is not None else None,
             resize_long_side=int(resize) if resize is not None else None,
@@ -250,7 +244,6 @@ class MultiPrecomputeTask:
     model_resolution: int
     resize_long_side: int
     limit: int
-    variants_per_sample: int
     batch_size: int
     num_workers: int
     store_distribution: bool
@@ -306,7 +299,6 @@ class MultiPrecomputeConfig:
         *,
         dataset_root_override: Optional[Path] = None,
         cache_override: Optional[Path] = None,
-        variants_override: Optional[int] = None,
         batch_override: Optional[int] = None,
         workers_override: Optional[int] = None,
         image_csv_override: Optional[Path] = None,
@@ -354,7 +346,6 @@ class MultiPrecomputeConfig:
                     else (cache_root / model.cache_subdir).resolve()
                 )
 
-            variants = variants_override or model.variants_per_sample or self.defaults.variants_per_sample
             base_batch = batch_override or model.batch_size or self.defaults.batch_size
             workers = workers_override or model.num_workers or self.defaults.num_workers
             resize = model.resize_long_side if model.resize_long_side is not None else self.defaults.resize_long_side
@@ -412,7 +403,6 @@ class MultiPrecomputeConfig:
                         model_resolution=resolution.model_resolution,
                         resize_long_side=int(resize_long_side),
                         limit=int(limit) if limit is not None else 0,
-                        variants_per_sample=max(1, int(variants)),
                         batch_size=effective_batch,
                         num_workers=max(0, int(workers)),
                         store_distribution=bool(store_distribution),


### PR DESCRIPTION
## Summary
- collapse the embedding cache to a single latent variant per image and compute missing entries by intersecting dataset paths with cached latents
- remove the `variants_per_sample` option from configs, CLI flags, and task generation in favor of one embedding per image
- update cache validation and dataset loading helpers to align with the simplified storage format

## Testing
- python -m compileall training

------
https://chatgpt.com/codex/tasks/task_b_68e632741cd08321ba52855877fbc911